### PR TITLE
Add Docker support for testing without local installation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+.git
+.gitignore
+Dockerfile
+docker-compose.yml
+npm-debug.log
+yarn-error.log
+pnpm-debug.log
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install --omit=dev
+
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/server ./server
+COPY --from=build /app/shared ./shared
+
+EXPOSE 5000
+
+CMD ["node", "server/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  app:
+    build: .
+    ports:
+      - "5000:5000"
+    environment:
+      NODE_ENV: production

--- a/server/vite.js
+++ b/server/vite.js
@@ -2,7 +2,6 @@ import express from "express";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
-import { createServer as createViteServer } from "vite";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -18,6 +17,7 @@ export function log(message) {
 }
 
 export async function setupVite(app, server) {
+  const { createServer: createViteServer } = await import("vite");
   const vite = await createViteServer({
     server: {
       middlewareMode: true,


### PR DESCRIPTION
This PR adds a Dockerfile so the project can be tested without installing dependencies locally.

I kept the change minimal and didn’t update the README, but I can add Docker instructions if you think it’s useful.
